### PR TITLE
only push images to docker hub on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,27 @@
+default_machine: &default_machine
+  machine:
+    # might not have any effect, since dlc is a premium feature
+    docker_layer_caching: true
+
 version: 2
 jobs:
   build:
-    machine:
-      # might not have any effect, since dlc is a premium feature
-      docker_layer_caching: true
+    <<: *default_machine
+    steps:
+      - checkout
+      - run:
+          name: build images
+          command: |
+            ./build.sh build yeldir
+      - run:
+          name: test images
+          command: |
+            ./build.sh test
+  build_and_publish:
+    <<: *default_machine
+    filters:
+      branches:
+        only: master
     steps:
       - checkout
       - run:


### PR DESCRIPTION
CircleCI config rewritten to only login und push images to docker hub on the master branch.

Unfortunately circleci workflows don't support image sharing yet ([at least for free users](https://discuss.circleci.com/t/caching-docker-images-in-workflows/16507)). Thus we have to duplicate some config.

This will resolve #10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yeldirium/st3k101/15)
<!-- Reviewable:end -->
