### PR TITLE
[BUGFIX] make missing modals scrollable

### DIFF
--- a/frontend/src/components/Partials/Modal/ForgetDataSubject.vue
+++ b/frontend/src/components/Partials/Modal/ForgetDataSubject.vue
@@ -3,6 +3,7 @@
            height="auto"
            width="80%"
            @before-open="beforeOpen"
+           :scrollable="true"
     >
         <div class="container">
             <span class="container__header">Forget DataSubject</span>

--- a/frontend/src/components/Partials/Modal/UpdateAllRangeLabels.vue
+++ b/frontend/src/components/Partials/Modal/UpdateAllRangeLabels.vue
@@ -4,6 +4,7 @@
            :width="width"
            @before-open="beforeOpen"
            class="modal"
+           :scrollable="true"
     >
         <div class="modal__header">
             Update all range labels for dimension


### PR DESCRIPTION
This resolves #69 , also includes ForgetDataSubject modal, which was also not scrollable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yeldirium/st3k101/70)
<!-- Reviewable:end -->
