### PR TITLE
[BUGFIX] send confirmation emails

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,7 @@ FROM tiangolo/uwsgi-nginx-flask:python3.6
 
 COPY ./app /app
 
-RUN pip install --upgrade pip && pip install -r /app/requirements.txt
-RUN apt update && apt install -y sendmail
+RUN pip install -r /app/requirements.txt
 
 WORKDIR /app
 RUN pybabel compile -d translations

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,8 @@ FROM tiangolo/uwsgi-nginx-flask:python3.6
 
 COPY ./app /app
 
-RUN pip install -r /app/requirements.txt
+RUN pip install --upgrade pip && pip install -r /app/requirements.txt
+RUN apt update && apt install -y sendmail
 
 WORKDIR /app
 RUN pybabel compile -d translations

--- a/backend/app/api/Response.py
+++ b/backend/app/api/Response.py
@@ -10,6 +10,7 @@ from api.schema.Submission import SubmissionSchema
 from auth.roles import Role, needs_minimum_role
 from auth.session import current_user
 from framework.captcha import validate_captcha
+from framework.internationalization import _
 from framework.signals import SIG_ANSWERS_VALIDATED
 from framework.xapi.XApiPublisher import XApiPublisher
 from framework.xapi.submission_hooks import do_submission_hooks
@@ -21,7 +22,7 @@ from model.models.QuestionResponse import QuestionResponse
 from model.models.Questionnaire import Questionnaire
 from utils import generate_verification_token
 from utils.dicts import merge_error_dicts
-from framework.email import validate_email_blacklist, validate_email_whitelist
+from framework.email import validate_email_blacklist, validate_email_whitelist, construct_verification_email, send_mail
 
 __author__ = "Noah Hummel"
 
@@ -148,6 +149,12 @@ class ResponseListForQuestionnaireResource(Resource):
                 'missing': list(all_questions)
             }, 400
 
+        send_mail(
+            data_subject.email,
+            _("Please verify your survey submission"),
+            construct_verification_email(questionnaire, verification_token)
+        )
+
         db.session.commit()
         return {
             'message': 'Submission successful. Please verify by email.'
@@ -252,6 +259,7 @@ class LtiResponseResource(Resource):
         return {
             'message': 'Submission successful.'
         }, 200
+
 
 api.add_resource(
     ResponseListForQuestionnaireResource,

--- a/backend/app/framework/email.py
+++ b/backend/app/framework/email.py
@@ -5,7 +5,17 @@ from typing import List, Pattern
 
 from flask import g
 
+from framework.internationalization import _
+
 __author__ = "Noah Hummel, Hannes Leutloff"
+
+
+def construct_verification_email(questionnaire, verification_token) -> str:
+    if __name__ == '__main__':
+        message = _("Hi there!\n You've recently participated in the survey ") + questionnaire.name + ".\n"
+        message += _("To verify that you're actually you and make your answer count, please follow the link below:\n\n")
+        message += "http://{}/api/response/verify/{}\n\n".format(g._config['DOMAIN_NAME'], verification_token)  # TODO https
+        return message
 
 
 def send_mail(to: str, subject: str, message: str) -> None:

--- a/backend/app/framework/email.py
+++ b/backend/app/framework/email.py
@@ -1,5 +1,3 @@
-from subprocess import Popen, PIPE
-
 import re
 import smtplib
 from email.mime.text import MIMEText
@@ -7,69 +5,34 @@ from typing import List, Pattern
 
 from flask import g
 
-from framework.internationalization import _
-
 __author__ = "Noah Hummel, Hannes Leutloff"
 
 
-def construct_verification_email(questionnaire, verification_token) -> str:
-    if __name__ == '__main__':
-        message = _("Hi there!\n You've recently participated in the survey ") + questionnaire.name + ".\n"
-        message += _("To verify that you're actually you and make your answer count, please follow the link below:\n\n")
-        message += "http://{}/api/response/verify/{}\n\n".format(g._config['DOMAIN_NAME'], verification_token)  # TODO https
-        return message
-
-
-def send_mail(to: str, subject: str, message: str):
-    if g._config['USE_SMTP']:
-        send_mail_smtp(to, subject, message)
-    else:
-        send_mail_sendmail(to, subject, message)
-
-
-def construct_email(sender, recipient, subject, message) -> str:
-    """
-    Constructs RFC2822 compliant email string.
-    :param sender: The sender
-    :param recipient: The recipient
-    :param subject: The subject line
-    :param message: The message body
-    :return: RFC2822 compliant email string
-    """
-    email = MIMEText(message)
-    email['Subject'] = subject
-    email['From'] = sender
-    email['To'] = recipient
-    return email.as_string()
-
-
-def send_mail_smtp(to: str, subject: str, message: str):
+def send_mail(to: str, subject: str, message: str) -> None:
     """
     A helper method to wrap interaction with smtplib in order to send emails.
-
+    
     :param to: str The email address of the recipient.
-    :param subject: str The subject line
+    :param subject: str The subject line 
     :param message: str The mail body
     :return: None
     """
+
     sender = g._config["SMTP_FROM_ADDRESS"]
+    receivers = [to]
     server = g._config["SMTP_SERVER"]
     port = g._config["SMTP_PORT"]
 
-    email =  construct_email(sender, to, subject, message)
+    email = MIMEText(message)
+    email['Subject'] = subject
+    email['From'] = sender
+    email['To'] = to
 
     smtp = smtplib.SMTP(server, port=port)
     if g._config["SMTP_USE_STARTTLS"]:
         smtp.starttls()
     smtp.login(g._config["SMTP_FROM_ADDRESS"], g._config["SMTP_PASSWORD"])
-    smtp.sendmail(sender, [to], email)
-
-
-def send_mail_sendmail(to: str, subject: str, message: str):
-    from_address = "surveytool@{}".format(g._config["DOMAIN_NAME"])
-    email = construct_email(from_address, to, subject, message)
-    p = Popen(["/usr/sbin/sendmail", "-t", "-oi"], stdin=PIPE, universal_newlines=True)
-    p.communicate(email)
+    smtp.sendmail(sender, receivers, email.as_string())
 
 
 def parse_email_list(emails: List[str]) -> List[Pattern]:

--- a/backend/app/framework/email.py
+++ b/backend/app/framework/email.py
@@ -1,3 +1,5 @@
+from subprocess import Popen, PIPE
+
 import re
 import smtplib
 from email.mime.text import MIMEText
@@ -5,34 +7,69 @@ from typing import List, Pattern
 
 from flask import g
 
+from framework.internationalization import _
+
 __author__ = "Noah Hummel, Hannes Leutloff"
 
 
-def send_mail(to: str, subject: str, message: str) -> None:
-    """
-    A helper method to wrap interaction with smtplib in order to send emails.
-    
-    :param to: str The email address of the recipient.
-    :param subject: str The subject line 
-    :param message: str The mail body
-    :return: None
-    """
+def construct_verification_email(questionnaire, verification_token) -> str:
+    if __name__ == '__main__':
+        message = _("Hi there!\n You've recently participated in the survey ") + questionnaire.name + ".\n"
+        message += _("To verify that you're actually you and make your answer count, please follow the link below:\n\n")
+        message += "http://{}/api/response/verify/{}\n\n".format(g._config['DOMAIN_NAME'], verification_token)  # TODO https
+        return message
 
-    sender = g._config["SMTP_FROM_ADDRESS"]
-    receivers = [to]
-    server = g._config["SMTP_SERVER"]
-    port = g._config["SMTP_PORT"]
 
+def send_mail(to: str, subject: str, message: str):
+    if g._config['USE_SMTP']:
+        send_mail_smtp(to, subject, message)
+    else:
+        send_mail_sendmail(to, subject, message)
+
+
+def construct_email(sender, recipient, subject, message) -> str:
+    """
+    Constructs RFC2822 compliant email string.
+    :param sender: The sender
+    :param recipient: The recipient
+    :param subject: The subject line
+    :param message: The message body
+    :return: RFC2822 compliant email string
+    """
     email = MIMEText(message)
     email['Subject'] = subject
     email['From'] = sender
-    email['To'] = to
+    email['To'] = recipient
+    return email.as_string()
+
+
+def send_mail_smtp(to: str, subject: str, message: str):
+    """
+    A helper method to wrap interaction with smtplib in order to send emails.
+
+    :param to: str The email address of the recipient.
+    :param subject: str The subject line
+    :param message: str The mail body
+    :return: None
+    """
+    sender = g._config["SMTP_FROM_ADDRESS"]
+    server = g._config["SMTP_SERVER"]
+    port = g._config["SMTP_PORT"]
+
+    email =  construct_email(sender, to, subject, message)
 
     smtp = smtplib.SMTP(server, port=port)
     if g._config["SMTP_USE_STARTTLS"]:
         smtp.starttls()
     smtp.login(g._config["SMTP_FROM_ADDRESS"], g._config["SMTP_PASSWORD"])
-    smtp.sendmail(sender, receivers, email.as_string())
+    smtp.sendmail(sender, [to], email)
+
+
+def send_mail_sendmail(to: str, subject: str, message: str):
+    from_address = "surveytool@{}".format(g._config["DOMAIN_NAME"])
+    email = construct_email(from_address, to, subject, message)
+    p = Popen(["/usr/sbin/sendmail", "-t", "-oi"], stdin=PIPE, universal_newlines=True)
+    p.communicate(email)
 
 
 def parse_email_list(emails: List[str]) -> List[Pattern]:


### PR DESCRIPTION
Sending of emails was previously disabled due to missing smtp credentials. Since #79 was merged, credentials can be supplied in a safe manner, hence this PR enables email sending again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yeldirium/st3k101/81)
<!-- Reviewable:end -->
