### PR TITLE
[BUGFIX] Fixed wrong usage of the requests http library

### DIFF
--- a/backend/app/framework/xapi/XApiPublisher.py
+++ b/backend/app/framework/xapi/XApiPublisher.py
@@ -21,7 +21,7 @@ class XApiPublisher(metaclass=Singleton):
     def flush(self):
         for url, payload in self.__requests:
             if payload:
-                requests.post(url, json=json.dumps(payload))
+                requests.post(url, json=payload)
             else:
                 requests.post(url)
         self.__requests = []  # avoid sending duplicates, yes that happened.

--- a/debugging/lrs/server.py
+++ b/debugging/lrs/server.py
@@ -3,9 +3,10 @@ __author__ = "Noah Hummel"
 import pprint
 import random
 
-from flask import Flask, request, json, abort
+from flask import Flask, request, abort
 
 app = Flask(__name__)
+
 
 @app.route('/', methods=["GET", "POST"])
 def receive_xapi_statements():
@@ -14,11 +15,10 @@ def receive_xapi_statements():
     if random.random() >= 0.8:  # randomly drop statements to simulate flaky network
         abort(400)
 
-    data = json.loads(request.json)
-    if type(data) == list:
-        statements = [*data]
+    if type(request.json) == list:
+        statements = [*request.json]
     else:
-        statements = [data]
+        statements = [request.json]
 
     pp = pprint.PrettyPrinter(compact=True)
 

--- a/xapi-publisher/app/main.py
+++ b/xapi-publisher/app/main.py
@@ -79,8 +79,8 @@ def send_statement(statement: dict, receiver: str):
         'User-Agent': 'st3k101/2.0'
     }
     payload = json.dumps(statement) if type(statement) is not str else statement
-    req = requests.post(receiver, json=payload, headers=headers)
-    assert 200 <= req.status_code < 300
+    res = requests.post(receiver, data=payload, headers=headers)
+    assert 200 <= res.status_code < 300
 
 
 def flush():
@@ -99,9 +99,8 @@ def flush():
 
 @app.route('/enqueue/immediate', methods=['POST'])
 def enqueue_immediate():
-    data = json.loads(request.json)
-    statements = data['statements']
-    receivers = data['receivers']
+    statements = request.json['statements']
+    receivers = request.json['receivers']
     for statement in statements:
         enqueue(statement, receivers)
     return "Success"
@@ -109,9 +108,8 @@ def enqueue_immediate():
 
 @app.route('/enqueue/deferred/<survey_base_id>', methods=['POST'])
 def enqueue_deferred(survey_base_id: int=None):
-    data = json.loads(request.json)
-    statements = data['statements']
-    receivers = data['receivers']
+    statements = request.json['statements']
+    receivers = request.json['receivers']
     for statement in statements:
         enqueue(statement, receivers, survey_base_id)
     return "Success"


### PR DESCRIPTION
When using `json` kwarg in `requests.post()`, the payload does not have to be serialised manually, as it's already serialised by requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yeldirium/st3k101/95)
<!-- Reviewable:end -->
